### PR TITLE
Add directions for Julia on macOS because the Emacs GUI does not start from a shell

### DIFF
--- a/ob-julia-doc.org
+++ b/ob-julia-doc.org
@@ -45,29 +45,18 @@ subsequent updates are brief.
 
 ** Julia on macOS
 
-If you use macOS, you need to tell Emacs where to find =julia= because the GUI application does not start in a shell (see the answers and comments on [[this thread]] for more details). You'll need to add either of the following lines to =~/.bashrc=, which is loaded by all shells, unlike =~/.bash_profile=, which is loaded only by the login shell.
+If you use macOS, you need to tell Emacs where to find =julia= because the GUI application does not start in a shell (see the answers and comments on [[https://stackoverflow.com/questions/415403/whats-the-difference-between-bashrc-bash-profile-and-environment][this thread]] for more details). You'll need to add either of the following lines to =~/.bashrc=, which is loaded by all shells, unlike =~/.bash_profile=, which is loaded only by the login shell.
 
-Add an alias to the Julia executable with this line in =~/.bashrc=:
-#+BEGIN_SRC bash :eval never
-alias julia="/path/to/julia/binary"
-#+END_SRC
-
-Alternatively, add the Julia directory to the PATH with this line in =~/.bashrc=:
+Add the Julia directory to the PATH with this line in =~/.bashrc=:
 #+BEGIN_SRC bash :eval never
 export PATH="/path/to/julia/directory"
 #+END_SRC
 
-If you installed Julia in the default location, these become:
-
-#+BEGIN_SRC bash :eval never
-alias julia="/Applications/Julia-0.6.app/Contents/Resources/julia/bin/julia"
-#+END_SRC
+If you installed Julia in the default location, it becomes:
 
 #+BEGIN_SRC bash :eval never
 export PATH="Applications/Julia-0.6.app/Contents/Resources/julia/bin:$PATH"
 #+END_SRC
-
-Notice that the method with an alias points to the executable, the method with PATH points to the directory.
 
 ** ESS - Emacs Speaks Statistics
 

--- a/ob-julia-doc.org
+++ b/ob-julia-doc.org
@@ -55,7 +55,7 @@ export PATH="/path/to/julia/directory"
 If you installed Julia in the default location, it becomes:
 
 #+BEGIN_SRC bash :eval never
-export PATH="Applications/Julia-0.6.app/Contents/Resources/julia/bin:$PATH"
+export PATH="/Applications/Julia-0.6.app/Contents/Resources/julia/bin:$PATH"
 #+END_SRC
 
 ** ESS - Emacs Speaks Statistics

--- a/ob-julia-doc.org
+++ b/ob-julia-doc.org
@@ -43,6 +43,32 @@ _Fair warning:_ the initial install takes a /long time/, largely
 because julia has a lot of dependencies. Never fear, though;
 subsequent updates are brief.
 
+** Julia on macOS
+
+If you use macOS, you need to tell Emacs where to find =julia= because the GUI application does not start in a shell (see the answers and comments on [[this thread]] for more details). You'll need to add either of the following lines to =~/.bashrc=, which is loaded by all shells, unlike =~/.bash_profile=, which is loaded only by the login shell.
+
+Add an alias to the Julia executable with this line in =~/.bashrc=:
+#+BEGIN_SRC bash :eval never
+alias julia="/path/to/julia/binary"
+#+END_SRC
+
+Alternatively, add the Julia directory to the PATH with this line in =~/.bashrc=:
+#+BEGIN_SRC bash :eval never
+export PATH="/path/to/julia/directory"
+#+END_SRC
+
+If you installed Julia in the default location, these become:
+
+#+BEGIN_SRC bash :eval never
+alias julia="/Applications/Julia-0.6.app/Contents/Resources/julia/bin/julia"
+#+END_SRC
+
+#+BEGIN_SRC bash :eval never
+export PATH="Applications/Julia-0.6.app/Contents/Resources/julia/bin:$PATH"
+#+END_SRC
+
+Notice that the method with an alias points to the executable, the method with PATH points to the directory.
+
 ** ESS - Emacs Speaks Statistics
 
 You are going to need a relavely bleeding-edge version of ESS since it


### PR DESCRIPTION
Hello,

I've started using Julia from Org mode and followed your directions. I got stuck at running Julia at the section on ESS because `M-x julia` would fail. I understand it's specific to macOS and added directions for that.