### PR TITLE
Remove empty lines from results

### DIFF
--- a/ob-julia.el
+++ b/ob-julia.el
@@ -77,7 +77,10 @@ This function is called by `org-babel-execute-src-block'."
 	     (or (equal "yes" rownames-p)
 		 (org-babel-pick-name
 		  (cdr (assoc :rowname-names params)) rownames-p)))))
-      (if graphics-file nil result))))
+      (if graphics-file nil (replace-regexp-in-string
+                             "\\(\n\r?\\)\\{3,\\}"
+                             "\n"
+                             result)))))
 
 (defun org-babel-prep-session:julia (session params)
   "Prepare SESSION according to the header arguments specified in PARAMS."

--- a/ob-julia.el
+++ b/ob-julia.el
@@ -77,7 +77,7 @@ This function is called by `org-babel-execute-src-block'."
 	     (or (equal "yes" rownames-p)
 		 (org-babel-pick-name
 		  (cdr (assoc :rowname-names params)) rownames-p)))))
-      (if graphics-file nil (if (sequencep result)
+      (if graphics-file nil (if (and result (sequencep result))
                                 (org-babel-normalize-newline result)
                               result)))))
 

--- a/ob-julia.el
+++ b/ob-julia.el
@@ -77,10 +77,15 @@ This function is called by `org-babel-execute-src-block'."
 	     (or (equal "yes" rownames-p)
 		 (org-babel-pick-name
 		  (cdr (assoc :rowname-names params)) rownames-p)))))
-      (if graphics-file nil (replace-regexp-in-string
-                             "\\(\n\r?\\)\\{3,\\}"
-                             "\n"
-                             result)))))
+      (if graphics-file nil (if (sequencep result)
+                                (org-babel-normalize-newline result)
+                              result)))))
+
+(defun org-babel-normalize-newline (result)
+  (replace-regexp-in-string
+   "\\(\n\r?\\)\\{3,\\}"
+   "\n"
+   result))
 
 (defun org-babel-prep-session:julia (session params)
   "Prepare SESSION according to the header arguments specified in PARAMS."


### PR DESCRIPTION
This is a tentative fix for #8. It was tested with the code block
```
#+BEGIN_SRC julia :session :results output
1 + 1

# comment

212
#+END_SRC
```

i.e. running with a session and taking the output as evaluation results - which is a workaround for #9 as seen in https://github.com/gjkerns/ob-julia/issues/9#issuecomment-394425112.

Given that source block a user would see the result
```
#+RESULTS:
: 2
: 
: 
: 
: 212
```

whereas something like
```
#+RESULTS:
: 2
: 212
```

would be expected.

`ob-julia` is mainly based on `ob-R`. It looks as if `inferior-ess-send-input` works differently for Julia and R sessions in ESS. Specifically, in `ob-R` the result of evaluation is essentially one string containing the desired output. In `ob-julia` the result is one string per source block line (including "\n" for each comment line). These strings get concatenated to the final result containing all those newlines. The approach taken here is to replace excessive (i.e. three) consecutive newline characters with an appropriate number of newlines (i.e. one) in the resulting output string.

This does not feel like the correct fix, more like a workaround, but works without getting into different ESS session evaluation specifics. Please let me know if you can think of a better way.
